### PR TITLE
Like model update

### DIFF
--- a/Projects/Library/CocoaBloc/API/SBClient+Comment.h
+++ b/Projects/Library/CocoaBloc/API/SBClient+Comment.h
@@ -14,7 +14,7 @@
 // supports limit/offset
 - (RACSignal *)getCommentsForContent:(SBContent *)content parameters:(NSDictionary *)parameters;
 
-- (RACSignal *)getRepliesToComment:(SBComment *)comment;
+- (RACSignal *)getRepliesToComment:(SBComment *)comment parameters:(NSDictionary *)parameters;
 - (RACSignal *)deleteComment:(SBComment *)comment;
 
 - (RACSignal *)postCommentWithText:(NSString *)text onContent:(SBContent *)content;

--- a/Projects/Library/CocoaBloc/API/SBClient+Comment.m
+++ b/Projects/Library/CocoaBloc/API/SBClient+Comment.m
@@ -24,10 +24,10 @@
                 setNameWithFormat:@"Get comments for content: %@", content];
 }
 
-- (RACSignal *)getRepliesToComment:(SBComment *)comment {
+- (RACSignal *)getRepliesToComment:(SBComment *)comment parameters:(NSDictionary *)parameters {
     NSParameterAssert(comment);
     
-    return [[[self rac_GET:[NSString stringWithFormat:@"account/%@/%@/comment/%@/replies", comment.accountID, comment.content.identifier, comment.identifier] parameters:[self requestParametersWithParameters:nil]]
+    return [[[self rac_GET:[NSString stringWithFormat:@"account/%@/%@/comment/%@/replies", comment.accountID, comment.content.identifier, comment.identifier] parameters:[self requestParametersWithParameters:parameters]]
                 cb_deserializeArrayWithClient:self keyPath:@"data"]
                 setNameWithFormat:@"Get replies to comment: %@", comment];
 }


### PR DESCRIPTION
###Changes
- `getRepliesToComment:` -> `getRepliesToComment:parameters:`.
- SBClient now updates content which it is requesting to like/unlike, including on a failed request.