### PR TITLE
Fix Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ osx_image: xcode7.3
 xcode_project: CocoaBloc.xcodeproj
 
 before_install:
+    - brew unlink carthage || true
     - brew install carthage
 
 install:


### PR DESCRIPTION
Changes: Unlink carthage first, ignoring failure and then install it when doing the build test