### PR TITLE
Make public unmodeled request

### DIFF
--- a/CocoaBloc/Client.swift
+++ b/CocoaBloc/Client.swift
@@ -51,7 +51,7 @@ public final class APIClient<AuthStateType: AuthenticationStateType> {
 		return authenticationState.authenticationToken != nil
 	}
 	
-	internal func request<Serialized>(
+	public func request<Serialized>(
 		endpoint: Endpoint<Serialized>,
 		expansions: [API.ExpandableValue] = []) -> Request {
 		var params: [String: AnyObject] = [


### PR DESCRIPTION
This is needed for RACCB to support void models